### PR TITLE
This should fix Netlify not being able to deploy.

### DIFF
--- a/about/index.njk
+++ b/about/index.njk
@@ -62,8 +62,8 @@
 
         <p>
             <span class="marginnote">
-                <a href="http://folding.extremeoverclocking.com/user_summary.php?s=&u=666633">
-                    <img src="http://folding.extremeoverclocking.com/sigs/sigimage.php?u=666633&t=35947" alt="Folding @ Home"/>
+                <a href="https://folding.extremeoverclocking.com/user_summary.php?s=&u=666633">
+                    <img src="https://folding.extremeoverclocking.com/sigs/sigimage.php?u=666633&t=35947" alt="Folding @ Home"/>
                 </a>
             </span>
             For about six years staring from November 2014 I donated spare CPU cycles of computers I used to <a href="https://foldingathome.org/">Folding@Home</a> this was largely facilitated through the Folding@Home NaCL web client.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev:postcss": "postcss styles/main.css --o _tmp/style.css --watch",
     "dev:eleventy": "eleventy --serve",
-    "build": "cross-env ELEVENTY_PRODUCTION=true eleventy & cross-env NODE_ENV=production postcss styles/main.css --o _site/style.css"
+    "build": "cross-env ELEVENTY_PRODUCTION=true eleventy && cross-env NODE_ENV=production postcss styles/main.css --o _site/style.css"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The post css config needs to have the website built first so that it can then analyse what css is being used and cull the rest. Previously the css build would happen at the same time as the site being built, if the site build finished first then Netlify would consider the build complete and force quit any other running processes.