### PR TITLE
Bugfix, solves flash of un-styled content

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -10,9 +10,9 @@
     {% endif %}
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"/>
-    <link rel="stylesheet" href="/style.css?v={% version %}"/>
+    <link rel="stylesheet" href="/style.css"/>
     {% block head %}{% endblock %}
-    <script src="/js/alpine.js?v={% version %}"></script>
+    <script src="/js/alpine.js"></script>
 </head>
 <body class="{% block body_class %}{% endblock %}">
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,23 @@
 [build]
   publish = "_site"
   command = "npm run build"
+[[headers]]
+    for = "/*.svg"
+    [headers.values]
+        Cache-Control = "public, s-max-age=2592000"
+[[headers]]
+    for = "/*.ttf"
+    [headers.values]
+        Cache-Control = "public, s-max-age=2592000"
+[[headers]]
+    for = "/*.otf"
+    [headers.values]
+        Cache-Control = "public, s-max-age=2592000"
+[[headers]]
+    for = "/*.woff"
+    [headers.values]
+        Cache-Control = "public, s-max-age=2592000"
+[[headers]]
+    for = "/*.woff2"
+    [headers.values]
+        Cache-Control = "public, s-max-age=2592000"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,23 +1,3 @@
 [build]
   publish = "_site"
   command = "npm run build"
-[[headers]]
-    for = "/*.svg"
-    [headers.values]
-        Cache-Control = "public, s-max-age=2592000"
-[[headers]]
-    for = "/*.ttf"
-    [headers.values]
-        Cache-Control = "public, s-max-age=2592000"
-[[headers]]
-    for = "/*.otf"
-    [headers.values]
-        Cache-Control = "public, s-max-age=2592000"
-[[headers]]
-    for = "/*.woff"
-    [headers.values]
-        Cache-Control = "public, s-max-age=2592000"
-[[headers]]
-    for = "/*.woff2"
-    [headers.values]
-        Cache-Control = "public, s-max-age=2592000"


### PR DESCRIPTION
I incorrectly though that the flash of un-styled content was being caused due to the browser requesting the font files each page load and getting a 304 on response, with the flash being the time it took for that round trip.

In actual fact it was being caused by the addition of a `?version=...` suffix to the css and javascript imports. This version was supposed to be calculated once per build but instead it changes with each page that is generated; this had the result of the css being loaded for each new page visited leading to the additional requests for font files.

In browser testing this PR solves the issue limiting the flash of un-styled content to the first page load, which for the time being is acceptable.