### PR TITLE
Add <figure> shortcode.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const filters = require('./utils/filters')
 const collections = require('./utils/collections')
 const {slugify} = require('./utils/filters')
+const shortcodes = require('./utils/shortcodes');
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.setUseGitIgnore(false);
@@ -32,9 +33,10 @@ module.exports = function (eleventyConfig) {
     './img': './img'
   });
 
-  eleventyConfig.addShortcode("version", function () {
-    return String(Date.now())
-  });
+  for (const shortCode in shortcodes) {
+    eleventyConfig.addShortcode(shortCode, shortcodes[shortCode]);
+    console.log(shortCode);
+  }
 
   const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -13,12 +13,13 @@
     --dark-blue: #3fc2f6;
 }
 
+/* Links colours */
+
 a:link, a:visited {
     color: var(--red);
 }
 
-a:hover,
-a[aria-current]{
+a:hover, a[aria-current]{
     color: var(--yellow);
 }
 
@@ -31,17 +32,7 @@ a::selection{
     text-shadow: none;
 }
 
-pre{
-    background: var(--dark);
-    color: var(--light);
-    padding: 1rem 0;
-}
-
-blockquote {
-    border-left: 4px solid var(--red);
-    padding-left: 1rem;
-    margin-left: 0;
-}
+/* Post List Styles */
 
 ul.post-list{
     list-style:none;
@@ -50,4 +41,48 @@ ul.post-list{
 
 ul.post-list li {
     margin-bottom: 0.5rem;
+}
+
+/* Tufte.css extensions */
+
+pre{
+    background: var(--dark);
+    color: var(--light);
+}
+
+blockquote {
+    border-left: 4px solid var(--red);
+    padding-left: 1rem;
+    margin-left: 0;
+}
+
+.fullwidth {
+    max-width: 90%;
+    clear: both;
+    float: none;
+}
+
+p{
+    line-height: 1.8rem;
+    text-align: justify;
+}
+
+pre {
+    max-width: 90%;
+    border-radius: 0.5em;
+}
+
+img{
+    max-width: 100%;
+    min-width: 100%;
+}
+
+figure.fullwidth img {
+    float: none;
+}
+
+figure.fullwidth figcaption {
+    margin-right: 0;
+    max-width: 90%;
+    float: none;
 }

--- a/utils/shortcodes.js
+++ b/utils/shortcodes.js
@@ -1,0 +1,18 @@
+module.exports = {
+
+    /**
+     * @see https://gist.github.com/dirtystylus/d488ea82fec9ebda8308a288015d019b
+     * @param {string} image
+     * @param {string} caption
+     * @param {string} className
+     * @returns {string}
+     */
+    figure: (image, caption, className) => {
+        const classMarkup = className ? ` class="${className}"` : '';
+        const captionMarkup = caption ? `<figcaption>${caption}</figcaption>` : '';
+        return `<figure${classMarkup}><img src="${image}" />${captionMarkup}</figure>`;
+    },
+
+    version: () => String(Date.now()),
+
+}


### PR DESCRIPTION
Adds shortcode from [dirtystylus/eleventy-figure-shortcode.md](https://gist.github.com/dirtystylus/d488ea82fec9ebda8308a288015d019b) by [dirtystylus](https://twitter.com/dirtystylus) for inserting `<figure>`. Closes #41.

Usage:

```njk
{% figure "https://example.com/image.jpg", "Image caption", "class list or omitted" %}
```