### PR TITLE
Upgrade eleventy to 1.0

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,11 @@ const transforms = require('./utils/transforms');
 const wordStats = require('@photogabble/eleventy-plugin-word-stats');
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
+const UpgradeHelper = require("@11ty/eleventy-upgrade-help");
+
 module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(UpgradeHelper);
+
   eleventyConfig.setUseGitIgnore(false);
 
   eleventyConfig.addPlugin(wordStats);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,10 +32,6 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addTransform(transformName, transforms[transformName])
   })
 
-  // Merge data instead of overriding
-  // https://www.11ty.dev/docs/data-deep-merge/
-  eleventyConfig.setDataDeepMerge(true);
-
   eleventyConfig.addWatchTarget("./_tmp/style.css");
 
   // Don't process folders with static assets e.g. images

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "author": "Simon Dann",
   "license": "ISC",
   "devDependencies": {
-    "@11ty/eleventy": "^0.12.1",
+    "@11ty/eleventy": "^1.0.0",
     "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-plugin-rss": "^1.1.2",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^3.2.2",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
+    "@11ty/eleventy-upgrade-help": "^1.0.1",
     "@fullhuman/postcss-purgecss": "^4.1.3",
     "autoprefixer": "^10.4.2",
     "cross-env": "^7.0.3",

--- a/posts/2018-05-03-build-an-incremental-web-game-with-vue-js.md
+++ b/posts/2018-05-03-build-an-incremental-web-game-with-vue-js.md
@@ -1,5 +1,4 @@
 ---
-
 title: Build an incremental clicker web game with Vue.js - Part One
 draft: false
 cover_image: /img/featured-images/build-an-incremental-web-game-with-vue-js.png
@@ -10,6 +9,7 @@ tags:
     - javascript
     - vue.js
     - game
+templateEngineOverride: md
 ---
 
 For a while now I have had a tingling interest in gamedev, after a few false starts trying to build things too complicated and getting burnt out I thought it would be best to keep things simple and start by building a [incremental](https://www.reddit.com/r/incremental_games/) web game that I can add additional mechanics to as I progress. 
@@ -201,7 +201,7 @@ mounted: function() {
 
 Eventually the amount of food in your mining colony will reduce to zero and we can imagine that all 12 of the colonists hard at work each with empty bellies. This should affect their performance in some way and in the original _BASIC_ game this was conveyed to the player as a _satisfaction_ rating.
 
-![You're colonists are now starving...](/img/build-an-incremental-web-game-with-vue-js-2.png "You're colonists are now starving...")
+![Your colonists are now starving...](/img/build-an-incremental-web-game-with-vue-js-2.png "Your colonists are now starving...")
 
 Our satisfaction rating will be a float with a value between zero and one and for the time being will be influenced by the amount of food in the stores. To begin we add a `satisfaction` variable to our data function like so:
 

--- a/posts/posts.11tydata.js
+++ b/posts/posts.11tydata.js
@@ -1,0 +1,9 @@
+module.exports = {
+  featured: false,
+  layout: "layouts/post.njk",
+  eleventyComputed: {
+    permalink(data) {
+      return `blog/${ data.categories[0] }/${ this.slugify(data.title) }/`
+    }
+  }
+};

--- a/posts/posts.json
+++ b/posts/posts.json
@@ -1,5 +1,0 @@
-{
-  "permalink": "blog/{{ categories | first }}/{{ title | slugify }}/index.html",
-  "featured": false,
-  "layout": "layouts/post.njk"
-}


### PR DESCRIPTION
A big thank you to @pdehaan for solving a blocking issue (see https://github.com/11ty/eleventy/issues/2273) that had me stumped. The fix that I have gone with means I wont be able to use the figure short code in `posts/2018-05-03-build-an-incremental-web-game-with-vue-js.md` but thats fine.

I have chosen to leave `@11ty/eleventy-upgrade-help` for the time being as it's still giving some warnings but nothing in my 
code seems to be triggering them.