### PR TITLE
Feature: Filter stub files from being normally discoverable

### DIFF
--- a/_includes/components/growth.njk
+++ b/_includes/components/growth.njk
@@ -1,4 +1,8 @@
-{% if growthStage === 'seedling' %}
+{% if growthStage === 'stub' %}
+    {% set growthIcon = '👩‍🌾' %}
+    {% set growthTitle = 'Stubs are placeholders for pages I will be publishing soon.' %}
+    {% set growthText = 'Stub' %}
+{% elif growthStage === 'seedling' %}
     {% set growthIcon = '🌱' %}
     {% set growthTitle = 'Seedlings are rough and early ideas, they need further work and are likely to change often' %}
     {% set growthText = 'Seedling' %}

--- a/about/growth.njk
+++ b/about/growth.njk
@@ -18,9 +18,10 @@
         I quite like Maggie's horticultural approach and so will be borrowing her three metaphors:
     </p>
     <ul>
+        <li>👩‍🌾 <em>Stubs</em> placeholders for content coming "soon"</li>
         <li>🌱 <em>Seedlings</em> for very rough and early ideas</li>
         <li>🌿 <em>Budding</em> for work I've cleaned up and clarified</li>
-        <li>🌳 <em>Evergreen</em> for work that is reasonably complete.</li>
+        <li>🌳 <em>Evergreen</em> for work that is reasonably complete</li>
     </ul>
 </article>
 {% endblock %}

--- a/blog.njk
+++ b/blog.njk
@@ -1,6 +1,6 @@
 {% extends "_includes/layouts/page.njk" %}
 
-{% set postsList = collections.post | excludeTypes(['mirror']) | reverse %}
+{% set postsList = collections.post | excludeStubs | excludeTypes(['mirror']) | reverse %}
 {% set title = 'Blog Archive' %}
 
 {% block content %}

--- a/index.njk
+++ b/index.njk
@@ -1,6 +1,6 @@
 {% extends "_includes/layouts/base.njk" %}
 
-{% set articlesList = collections.post %}
+{% set articlesList = collections.post | excludeStubs %}
 
 {% block header %}
   <h1><span class="selected">Hey</span>, I'm Simon.</h1>

--- a/rss.njk
+++ b/rss.njk
@@ -2,7 +2,7 @@
     permalink: "blog/feed.xml"
     eleventyExcludeFromCollections: true
 ---
-{% set postsList = collections.post | excludeTypes(['project', 'mirror']) %}<?xml version="1.0" encoding="utf-8"?>
+{% set postsList = collections.post | excludeStubs | excludeTypes(['project', 'mirror']) %}<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-GB">
     <title type="text">{{ metadata.title }}</title>
     <subtitle type="text">{{ metadata.description }}</subtitle>

--- a/utils/collections.js
+++ b/utils/collections.js
@@ -17,7 +17,7 @@ const paginateContentTaxonomy = (baseSlug = '', perPage = 10) => {
       pages.push({
         title: taxonomy.name,
         slug: slugs[idx],
-        pageNumber: idx+1,
+        pageNumber: idx + 1,
         totalPages,
         pageSlugs: {
           all: slugs,
@@ -42,21 +42,19 @@ const post = (collection) => (process.env.ELEVENTY_ENV !== 'production')
 // @see https://github.com/photogabble/website/issues/20
 const contentTags = (collection) => Array.from(
   post(collection).reduce((tags, post) => {
-    if (post.data.tags) {
-      post.data.tags.forEach(tag => tags.add(tag))
-    }
+    if (post.data.tags) post.data.tags.forEach(tag => tags.add(tag));
     return tags;
   }, new Set())
 ).map(name => {
   return {
     name,
     slug: slugify(name),
-    items: collection.getFilteredByTag(name).reverse()
+    items: collection.getFilteredByTag(name).filter((item) => item.data.growthStage && item.data.growthStage !== 'stub') .reverse()
   }
-}).sort((a,b) => b.items.length - a.items.length);
+}).sort((a, b) => b.items.length - a.items.length);
 
 const contentTypes = (collection) => Object.values(post(collection).reverse().reduce((types, post) => {
-  types[post.data.contentType].items.push(post);
+  if (post.data.growthStage && post.data.growthStage !== 'stub') types[post.data.contentType].items.push(post);
   return types;
 }, {
   thought: {

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -71,6 +71,8 @@ module.exports = {
      */
     limit: (array, limit) => array.slice(0, limit),
 
+    excludeStubs: (collection) => collection.filter(item => item.data.growthStage && item.data.growthStage !== 'stub'),
+
     excludeType: (collection, type) => {
         return (!type)
             ? collection


### PR DESCRIPTION
I have recently begun using the wikilinks functionality I wrote a while back to reference pages that do not yet exist. In order to keep them as reference I have been adding stub pages to be filled out in future. 

Files marked as stubs shouldn't be normally discoverable via the archive, feeds, or any post list. They can however be referenced via wikilink which will take the visitor to the stub page.