### PR TITLE
[Feature] Do not crash on invalid wikilink

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -99,5 +99,8 @@ module.exports = function (eleventyConfig) {
     }).use(markdownItAnchor, {
       permalink: false,
       slugify: input => slugify(input)
-    }).use(markdownFootnote).use(require('./utils/helpers/wikilinks'), linkMapCache));
+    }).use(require('./utils/helpers/wikilinks'), {
+      linkMapCache,
+      eleventyConfig
+    }).use(markdownFootnote));
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fullhuman/postcss-purgecss": "^4.1.3",
     "@photogabble/eleventy-plugin-word-stats": "^1.0.0",
     "autoprefixer": "^10.4.8",
+    "chalk": "^4.1.1",
     "cross-env": "^7.0.3",
     "eleventy-plugin-postcss": "^1.0.4",
     "flat-cache": "^3.0.4",

--- a/utils/helpers/map.js
+++ b/utils/helpers/map.js
@@ -1,2 +1,2 @@
-let map = new Map([]);
+let map = new Map();
 module.exports = map;

--- a/utils/helpers/wikilinks.js
+++ b/utils/helpers/wikilinks.js
@@ -1,23 +1,35 @@
 const {slugify} = require("../filters");
+const chalk = require("chalk");
 
-module.exports = function(md, linkMapCache) {
+module.exports = function (md, {linkMapCache, eleventyConfig}) {
+  const deadWikiLinks = new Set();
+
+  eleventyConfig.on('eleventy.after', () => {
+    deadWikiLinks.forEach(
+      slug => console.warn(chalk.blue('[@photogabble/wikilinks]'), chalk.yellow('WARNING'), `WikiLink found pointing to non-existent [${slug}], has been set to default stub.`)
+    );
+  });
+
   // Recognize Mediawiki links ([[text]])
   md.linkify.add("[[", {
     validate: /^\s?([^\[\]\|\n\r]+)(\|[^\[\]\|\n\r]+)?\s?\]\]/,
     normalize: match => {
       const parts = match.raw.slice(2, -2).split("|");
       const slug = slugify(parts[0].replace(/.(md|markdown)\s?$/i, "").trim());
-      const found = linkMapCache.get(slug);
+      let found = linkMapCache.get(slug);
 
       if (!found) {
-        throw new Error(`Unable to find page linked by wikilink slug [${slug}]`)
+        deadWikiLinks.add(slug);
+        match.text = parts.length === 2 ? parts[1] : parts[0];
+        match.url = '/stubs';
+        return;
       }
 
       match.text = parts.length === 2
         ? parts[1]
         : found.title;
 
-      match.url = found.permalink.substring(0,1) === '/'
+      match.url = found.permalink.substring(0, 1) === '/'
         ? found.permalink
         : `/${found.permalink}`;
     }


### PR DESCRIPTION
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/464699/215291760-e2ace6fe-a0c7-4880-99e8-b6cff3d14391.png">

Instead of crashing the build this will now report which links are invalid and have them direct to https://www.photogabble.co.uk/stubs which contains some explanation as to what has happened for the visitor.

Closes #61.