### PR TITLE
[Feature] Archive grouped by year and month

### DIFF
--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -19,7 +19,7 @@ module.exports = {
           crumbs.push({href: '/about/content', text: 'types', title: 'Goto Content Types info page'});
           break;
         case 'writing':
-          crumbs.push({href: '/blog', text: 'writing', title: 'Goto Archive of all posts'});
+          crumbs.push({href: '/writing', text: 'writing', title: 'Goto Archive of all posts'});
           break;
         case 'topic':
           crumbs.push({href: '/topic', text: 'topics', title: 'Goto list of all topics'});

--- a/_includes/components/months-of-year.njk
+++ b/_includes/components/months-of-year.njk
@@ -1,0 +1,8 @@
+{% for month in range(0, 12) | reverse %}
+    {% set label = (month+1) | padStart(2, '0')  %}
+    {% if postsByMonth.get(month).length > 0 %}
+        <a href="/writing/{{ year }}/{{ label }}">{{ label }}</a>
+    {% else %}
+        {{ label }}
+    {% endif %}
+{% endfor %}

--- a/_includes/components/planting-times.njk
+++ b/_includes/components/planting-times.njk
@@ -1,0 +1,20 @@
+<nav class="dates-list">
+    <h2>Planted throughout the seasons</h2>
+
+    {% set allPosts = collections.post | excludeStubs | excludeTypes(['mirror']) | reverse %}
+    {% set postsByYear = allPosts | groupByYear %}
+
+    <ol class="post-list">
+    {% for year, items in postsByYear %}
+        <li>
+            <strong>{{ year }}</strong>
+            <hr/>
+            {% set postsByMonth = items | groupByMonth %}
+            {% set year = year %}
+            <small>
+                {% include './months-of-year.njk' %}
+            </small>
+        </li>
+    {% endfor %}
+    </ol>
+</nav>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -167,7 +167,7 @@
     <dl>
         <dt><a href="/" title="Back to home" class="no-underline">🌱</a> Simon Dann</dt>
         <dd><a href="/projects" title="My Current and past projects">Projects</a></dd>
-        <dd><a href="/blog" title="The Digital Garden Archive">Archive</a></dd>
+        <dd><a href="/writing" title="The Digital Garden Archive">Archive</a></dd>
         <dd><a href="/books" title="What I have been reading">Bookshelf</a></dd>
         <dd><a href="/uses" title="A somewhat complete list of tools, applications, hardware and services that I used on a day-to-day basis.">/uses</a></dd>
         <dd><a href="/now" title="A big picture glimpse into my what I’m focused on now">/now</a></dd>

--- a/_redirects
+++ b/_redirects
@@ -1,6 +1,9 @@
 # Feed
 /atom.xml /blog/feed.xml
 
+# Blog moved to Writing (final vestige of blog to digital garden conversion)
+/blog/ /writing/
+
 # Movement of pages into glossary
 /about/content/ /glossary/content-types/
 /about/growth/ /glossary/growth/

--- a/archive.njk
+++ b/archive.njk
@@ -10,9 +10,11 @@ folder: writing
 {% extends "_includes/layouts/page.njk" %}
 {% set title = yearMonth.title %}
 {% block content %}
-  <h1>{{ yearMonth.title }}</h1>
+  <section>
+    <h1>{{ yearMonth.title }}</h1>
 
-  {% set displayContentType = true %}
-  {% set postsList = yearMonth.items | reverse %}
-  {% include "_includes/components/post-list.njk" %}
+    {% set displayContentType = true %}
+    {% set postsList = yearMonth.items | reverse %}
+    {% include "_includes/components/post-list.njk" %}
+  </section>
 {% endblock %}

--- a/archive.njk
+++ b/archive.njk
@@ -1,0 +1,20 @@
+---
+pagination:
+  data: collections.contentPaginatedByYearMonth
+  size: 1
+  alias: yearMonth
+permalink: /archive/{{ yearMonth.slug }}/index.html
+---
+
+{% extends "_includes/layouts/page.njk" %}
+
+{% block content %}
+
+  <h1>{{ yearMonth.title }}</h1>
+
+  {% set displayContentType = true %}
+  {% set postsList = yearMonth.items | reverse %}
+  {% include "_includes/components/post-list.njk" %}
+
+{{ yearMonth | debug }}
+{% endblock %}

--- a/archive.njk
+++ b/archive.njk
@@ -4,17 +4,15 @@ pagination:
   size: 1
   alias: yearMonth
 permalink: /archive/{{ yearMonth.slug }}/index.html
+folder: writing
 ---
 
 {% extends "_includes/layouts/page.njk" %}
-
+{% set title = yearMonth.title %}
 {% block content %}
-
   <h1>{{ yearMonth.title }}</h1>
 
   {% set displayContentType = true %}
   {% set postsList = yearMonth.items | reverse %}
   {% include "_includes/components/post-list.njk" %}
-
-{{ yearMonth | debug }}
 {% endblock %}

--- a/blog.njk
+++ b/blog.njk
@@ -1,14 +1,21 @@
 {% extends "_includes/layouts/page.njk" %}
 
-{% set postsList = collections.post | excludeStubs | excludeTypes(['mirror']) | reverse %}
+{% set allPosts = collections.post | excludeStubs | excludeTypes(['mirror']) | reverse %}
+{% set postsByYear = allPosts | groupByYear %}
 {% set title = 'Blog Archive' %}
 
 {% block content %}
     <h1>Archive</h1>
-    <p>There have been <strong>{{ postsList.length }}</strong> items published since April 20, 2007:</p>
-    <section>
-        {% set displayContentType = true %}
-        {% include "_includes/components/post-list.njk" %}
-    </section>
+    <p>There have been <strong>{{ allPosts.length }}</strong> items published since April 20, 2007:</p>
+
+    {% for year, items in postsByYear %}
+        <section>
+            <h3>{{ year }}</h3>
+            {% set displayContentType = true %}
+            {% set postsList = items %}
+            {% include "_includes/components/post-list.njk" %}
+        </section>
+    {% endfor %}
+
     {% include '_includes/components/hot-topics.njk' %}
 {% endblock %}

--- a/blog.njk
+++ b/blog.njk
@@ -10,7 +10,20 @@
 
     {% for year, items in postsByYear %}
         <section>
-            <h3>{{ year }}</h3>
+            <header>
+                <h3>{{ year }}</h3>
+                <nav>
+                    {% set postsByMonth = items | groupByMonth %}
+                    {% for month in range(0, 12) | reverse %}
+                        {% set label = (month+1) | padStart(2, '0')  %}
+                        {% if postsByMonth.get(month).length > 0 %}
+                            <a href="/archive/{{ year }}/{{ label }}">{{ label }}</a>
+                        {% else %}
+                            {{ label }}
+                        {% endif %}
+                    {% endfor %}
+                </nav>
+            </header>
             {% set displayContentType = true %}
             {% set postsList = items %}
             {% include "_includes/components/post-list.njk" %}

--- a/index.njk
+++ b/index.njk
@@ -18,7 +18,7 @@
     {% set postsList = articlesList | excludeTypes(['thought', 'project', 'mirror']) | reverse | limit(6) %}
     {% include "_includes/components/post-list.njk" %}
     <p>
-      Subscribe to the <a href="/blog/feed.xml">RSS Feed</a> or view the entire <a href="/blog">archive</a> for more.
+      Subscribe to the <a href="/blog/feed.xml">RSS Feed</a> or view the entire <a href="/writing">archive</a> for more.
     </p>
   </section>
 

--- a/utils/collections.js
+++ b/utils/collections.js
@@ -129,7 +129,7 @@ module.exports = function loadCollection(eleventyConfig) {
       const key = `${post.date.getFullYear()}/${post.date.getMonth()}`;
       const month = (post.date.getMonth() + 1);
       const segment = carry.get(key) ?? {
-        title: `Posts published ${month}/${post.date.getFullYear()}`,
+        title: `Planted in ${post.date.toLocaleString('en-us', { month: 'long' })}/${post.date.getFullYear()}`,
         slug: `${post.date.getFullYear()}/${padStart(month, 2, '0')}`,
         pageNumber: 1,
         totalPages: 1,

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -158,6 +158,22 @@ module.exports = {
     }, new Map()),
 
   /**
+   * Group a collection by month.
+   * @param collection
+   * @returns {*}
+   */
+  groupByMonth: (collection) => collection
+    .reduce((carry, post) => {
+      const month = post.date.getMonth();
+      const group = carry.get(month) ?? [];
+      group.push(post);
+      carry.set(month, group);
+      return carry;
+    }, new Map()),
+
+  padStart: (str, len, filler) => String(str).padStart(len, filler),
+
+  /**
    * Takes a 11ty collection and returns a stats object for presentation
    * TODO: turn this into a 11ty plugin...
    */

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -143,6 +143,21 @@ module.exports = {
   includesTag: (tags, slug) => tags.find(tag => tag.toLowerCase() === slug.toLowerCase()) !== undefined,
 
   /**
+   * Group a collection by year.
+   *
+   * @param collection
+   * @returns {*}
+   */
+  groupByYear: (collection) => collection
+    .reduce((carry, post) => {
+      const year = post.date.getFullYear();
+      const group = carry.get(year) ?? [];
+      group.push(post);
+      carry.set(year, group);
+      return carry;
+    }, new Map()),
+
+  /**
    * Takes a 11ty collection and returns a stats object for presentation
    * TODO: turn this into a 11ty plugin...
    */

--- a/writing/archive.njk
+++ b/writing/archive.njk
@@ -17,4 +17,6 @@ folder: writing
     {% set postsList = yearMonth.items | reverse %}
     {% include "../_includes/components/post-list.njk" %}
   </section>
+
+  {% include '../_includes/components/planting-times.njk' %}
 {% endblock %}

--- a/writing/archive.njk
+++ b/writing/archive.njk
@@ -3,11 +3,11 @@ pagination:
   data: collections.contentPaginatedByYearMonth
   size: 1
   alias: yearMonth
-permalink: /archive/{{ yearMonth.slug }}/index.html
+permalink: /writing/{{ yearMonth.slug }}/index.html
 folder: writing
 ---
 
-{% extends "_includes/layouts/page.njk" %}
+{% extends "../_includes/layouts/page.njk" %}
 {% set title = yearMonth.title %}
 {% block content %}
   <section>
@@ -15,6 +15,6 @@ folder: writing
 
     {% set displayContentType = true %}
     {% set postsList = yearMonth.items | reverse %}
-    {% include "_includes/components/post-list.njk" %}
+    {% include "../_includes/components/post-list.njk" %}
   </section>
 {% endblock %}

--- a/writing/index.njk
+++ b/writing/index.njk
@@ -14,14 +14,8 @@
                 <h3>{{ year }}</h3>
                 <nav>
                     {% set postsByMonth = items | groupByMonth %}
-                    {% for month in range(0, 12) | reverse %}
-                        {% set label = (month+1) | padStart(2, '0')  %}
-                        {% if postsByMonth.get(month).length > 0 %}
-                            <a href="/writing/{{ year }}/{{ label }}">{{ label }}</a>
-                        {% else %}
-                            {{ label }}
-                        {% endif %}
-                    {% endfor %}
+                    {% set year = year %}
+                    {% include '../_includes/components/months-of-year.njk' %}
                 </nav>
             </header>
             {% set displayContentType = true %}

--- a/writing/index.njk
+++ b/writing/index.njk
@@ -1,4 +1,4 @@
-{% extends "_includes/layouts/page.njk" %}
+{% extends "../_includes/layouts/page.njk" %}
 
 {% set allPosts = collections.post | excludeStubs | excludeTypes(['mirror']) | reverse %}
 {% set postsByYear = allPosts | groupByYear %}
@@ -17,7 +17,7 @@
                     {% for month in range(0, 12) | reverse %}
                         {% set label = (month+1) | padStart(2, '0')  %}
                         {% if postsByMonth.get(month).length > 0 %}
-                            <a href="/archive/{{ year }}/{{ label }}">{{ label }}</a>
+                            <a href="/writing/{{ year }}/{{ label }}">{{ label }}</a>
                         {% else %}
                             {{ label }}
                         {% endif %}
@@ -26,9 +26,9 @@
             </header>
             {% set displayContentType = true %}
             {% set postsList = items %}
-            {% include "_includes/components/post-list.njk" %}
+            {% include "../_includes/components/post-list.njk" %}
         </section>
     {% endfor %}
 
-    {% include '_includes/components/hot-topics.njk' %}
+    {% include '../_includes/components/hot-topics.njk' %}
 {% endblock %}


### PR DESCRIPTION
This PR adds year/month navigation:
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/464699/219977353-8b45ddf3-664b-477e-ba66-ae46c4904115.png">

Also splits archive page up by year with per year by month links:
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/464699/219977406-eb2af6cd-4d16-4691-8924-582824f15661.png">

Adds per month of year writing lists sections and redirects `/blog/` to `/writing/`

Closes #204.