### PR TITLE
Feat: Implements carbon footprint metrics in colophone page

### DIFF
--- a/colophon.njk
+++ b/colophon.njk
@@ -84,4 +84,11 @@ folder: 'about'
         </p>
         <p><small>&dagger;exemptions include <a href="/mirrored/">mirrored code snippets</a> which will each display their license terms if available.</small></p>
     </section>
+
+    <section>
+        <h2>Carbon Conscious Web Practices</h2>
+        <p>
+            For every visit to this site, only <a href="https://www.websitecarbon.com/website/photogabble-co-uk/" target="_blank">0.02g of CO2</a> is produced. I am unwavering in my commitment to decrease this value whenever possible, even if it means opting for a simpler design that may not suit everyone's taste.  The goal is to provide valuable content while treading lightly on our planet.
+        </p>
+    </section>
 {% endblock %}


### PR DESCRIPTION
Implements carbon footprint metrics on the colophone page, with a link to: 
[https://www.websitecarbon.com/website/photogabble-co-uk/](https://www.websitecarbon.com/website/photogabble-co-uk/)

Resolves #125 


<img width="1440" alt="image" src="https://github.com/photogabble/website/assets/44163914/fdb1c949-3fcb-4d09-bbdf-0fd87b72310f">
