### PR TITLE
Fix for long homepage title words causing horizontal scrolling on mobile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_size = 4
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Indentation override for all JS under lib directory
+[**.{js,njk}]
+indent_style = space
+indent_size = 2
+quote_type = single
+max_line_length = "80"
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2
+
+[*.{sass,css}]
+indent_style = space
+indent_size = 2

--- a/src/styles/components/_content-grid.css
+++ b/src/styles/components/_content-grid.css
@@ -9,25 +9,24 @@
     --content-max-width: 1400px;
 
     --content-size: calc(
-            (var(--content-max-width) - var(--paragraph-max-width))
+        (var(--content-max-width) - var(--paragraph-max-width))
     );
 }
 
 .content-grid {
     display: grid;
+    overflow: hidden;
+    text-wrap: balance;
     grid-template-columns:
-    [full-width-start] minmax(var(--padding-inline), 16rem)
-    [breakout-start] 0
-    [content-start] 0
-    [paragraph-start]
-        min(
-          100% - (var(--padding-inline) * 2),
-          var(--paragraph-max-width)
-        )
-    [paragraph-end]
-    minmax(0, var(--content-size))[content-end]
-    minmax(0, 7rem) [breakout-end]
-    minmax(var(--padding-inline), 1fr) [full-width-end];
+        [full-width-start] minmax(var(--padding-inline), 16rem)
+        [breakout-start] 0
+        [content-start] 0
+        [paragraph-start]
+        min(100% - (var(--padding-inline) * 2), var(--paragraph-max-width))
+        [paragraph-end]
+        minmax(0, var(--content-size)) [content-end]
+        minmax(0, 7rem) [breakout-end]
+        minmax(var(--padding-inline), 1fr) [full-width-end];
 }
 
 .content-grid > *,

--- a/src/styles/components/_content-grid.css
+++ b/src/styles/components/_content-grid.css
@@ -4,55 +4,53 @@
  */
 
 :root {
-    --padding-inline: 1rem;
-    --paragraph-max-width: 864px;
-    --content-max-width: 1400px;
+  --padding-inline: 1rem;
+  --paragraph-max-width: 864px;
+  --content-max-width: 1400px;
 
-    --content-size: calc(
-        (var(--content-max-width) - var(--paragraph-max-width))
-    );
+  --content-size: calc((var(--content-max-width) - var(--paragraph-max-width)));
 }
 
 .content-grid {
-    display: grid;
-    overflow: hidden;
-    text-wrap: balance;
-    grid-template-columns:
-        [full-width-start] minmax(var(--padding-inline), 16rem)
-        [breakout-start] 0
-        [content-start] 0
-        [paragraph-start]
-        min(100% - (var(--padding-inline) * 2), var(--paragraph-max-width))
-        [paragraph-end]
-        minmax(0, var(--content-size)) [content-end]
-        minmax(0, 7rem) [breakout-end]
-        minmax(var(--padding-inline), 1fr) [full-width-end];
+  display: grid;
+  overflow: hidden;
+  text-wrap: balance;
+  grid-template-columns:
+    [full-width-start] minmax(var(--padding-inline), 16rem)
+    [breakout-start] 0
+    [content-start] 0
+    [paragraph-start]
+    min(100% - (var(--padding-inline) * 2), var(--paragraph-max-width))
+    [paragraph-end]
+    minmax(0, var(--content-size)) [content-end]
+    minmax(0, 7rem) [breakout-end]
+    minmax(var(--padding-inline), 1fr) [full-width-end];
 }
 
 .content-grid > *,
 .full-width > *,
 article.content-grid section > * {
-    grid-column: content;
+  grid-column: content;
 }
 
 .content-grid > .paragraph,
 .full-width > .paragraph,
 article.content-grid section:not(.two-columns) > .paragraph {
-    grid-column: paragraph;
+  grid-column: paragraph;
 }
 
 .content-grid > .breakout,
 .full-width > .breakout,
 article.content-grid section:not(.two-columns) > .breakout {
-    grid-column: breakout;
+  grid-column: breakout;
 }
 
 .content-grid > .full-width,
 article.content-grid section:not(.two-columns) {
-    grid-column: full-width;
+  grid-column: full-width;
 
-    display: grid;
-    grid-template-columns: inherit;
+  display: grid;
+  grid-template-columns: inherit;
 }
 
 /*
@@ -60,35 +58,35 @@ article.content-grid section:not(.two-columns) {
  */
 article.content-grid p,
 article.content-grid ul {
-    grid-column: paragraph;
+  grid-column: paragraph;
 }
 
 /*
  * List of article elements that must be breakout width
  */
 article.content-grid pre {
-    grid-column: breakout;
+  grid-column: breakout;
 }
 
 .two-columns {
-    grid-column: content;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
+  grid-column: content;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
 }
 
 .two-columns__paragraph {
-    grid-template-columns: minmax(auto, var(--paragraph-max-width)) 1fr;
+  grid-template-columns: minmax(auto, var(--paragraph-max-width)) 1fr;
 }
 
 .two-columns > *,
 article.content-grid section.two-columns > * {
-    grid-column: auto;
+  grid-column: auto;
 }
 
 @media (max-width: 864px) {
-    .two-columns {
-        grid-template-columns: 1fr;
-        gap: 0;
-    }
+  .two-columns {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19,91 +19,92 @@
 @import "components/_terminal-tau.css";
 
 * {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 .container {
-  max-width: 1440px;
-  width: 75%;
-  margin-left: 12.5%;
-  margin-right: 12.5%;
+	max-width: 1440px;
+	width: 75%;
+	margin-left: 12.5%;
+	margin-right: 12.5%;
 }
 
 body {
-  font-family: "Iosevka Etoile", monospace;
-  background-color: var(--background);
-  color: var(--foreground);
+	font-family: "Iosevka Etoile", monospace;
+	background-color: var(--background);
+	color: var(--foreground);
 
-  font-size: 1rem;
-  line-height: 1.54;
-  letter-spacing: -0.02em;
-  text-rendering: optimizeLegibility;
-  font-feature-settings: "liga", "tnum", "case", "calt", "zero", "ss01", "locl";
-  font-variant-ligatures: contextual;
+	font-size: 1rem;
+	line-height: 1.54;
+	letter-spacing: -0.02em;
+	text-rendering: optimizeLegibility;
+	font-feature-settings: "liga", "tnum", "case", "calt", "zero", "ss01",
+		"locl";
+	font-variant-ligatures: contextual;
 
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  transition: background-color 300ms, color 200ms;
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	transition: background-color 300ms, color 200ms;
 }
 
 details summary {
-  cursor: pointer;
+	cursor: pointer;
 }
 
 blockquote {
-  margin-inline-start: 0;
-  font-style: italic;
-  border-left: 3px solid var(--foreground-muted);
-  padding-left: 1em;
-  color: var(--foreground-muted);
+	margin-inline-start: 0;
+	font-style: italic;
+	border-left: 3px solid var(--foreground-muted);
+	padding-left: 1em;
+	color: var(--foreground-muted);
 }
 
 aside.citation {
-    border-left: 3px solid var(--foreground-muted);
-    padding-left: 1em;
+	border-left: 3px solid var(--foreground-muted);
+	padding-left: 1em;
 }
 
 aside.citation blockquote {
-    border-left: none;
-    padding-left: 0;
+	border-left: none;
+	padding-left: 0;
 }
 
 pre {
-  background: var(--background-muted);
-  color: var(--foreground);
-  border-radius: 0.5em;
-  overflow: scroll;
-  padding: 1em;
+	background: var(--background-muted);
+	color: var(--foreground);
+	border-radius: 0.5em;
+	overflow: scroll;
+	padding: 1em;
 }
 
 p > code {
-  background: var(--foreground-muted);
-  color: var(--background);
-  padding: 0 3px;
-  border-radius: 3px;
+	background: var(--foreground-muted);
+	color: var(--background);
+	padding: 0 3px;
+	border-radius: 3px;
 }
 
 hr {
-  border: 0;
-  border-bottom: 3px double var(--foreground-muted);
-  margin: 2rem 0;
-  min-width: 1em;
+	border: 0;
+	border-bottom: 3px double var(--foreground-muted);
+	margin: 2rem 0;
+	min-width: 1em;
 }
 
 figure.fullwidth img {
-  float: none;
+	float: none;
 }
 
 figure.fullwidth figcaption {
-  margin-right: 0;
-  max-width: 90%;
-  float: none;
+	margin-right: 0;
+	max-width: 90%;
+	float: none;
 }
 
 a:link,
 a:visited {
-  color: var(--accent);
+	color: var(--accent);
 }
 
 /* With thanks to the user Shaz @ Stack Overflow
@@ -118,380 +119,385 @@ a[href]:not(:where(
   /* subdomains to exclude */
   [href*="//www.photogabble.co.uk"]
 )):not(.no-ext):after {
-  content: "↗️";
-  margin-left: 0.25rem;
-  vertical-align: super;
-  font-size: 0.5rem;
+	content: "↗️";
+	margin-left: 0.25rem;
+	vertical-align: super;
+	font-size: 0.5rem;
 }
 
 a.no-underline {
-  text-decoration: none;
+	text-decoration: none;
 }
 
 ::selection,
 .selected {
-  background-color: var(--accent);
-  color: var(--background);
+	background-color: var(--accent);
+	color: var(--background);
 }
 
 .selected {
-  padding: 0 0.2rem;
+	padding: 0 0.2rem;
 }
 
 main,
 header {
-  display: flex;
-  flex-direction: column;
+	display: flex;
+	flex-direction: column;
 }
 
 main {
-  font-size: 1.2em;
-  flex-grow: 1;
-  margin-bottom: 2em;
+	font-size: 1.2em;
+	flex-grow: 1;
+	margin-bottom: 2em;
+}
+
+main > section {
+	text-wrap: balance;
+	text-wrap: pretty;
+	overflow: hidden;
 }
 
 article > header {
-  padding: 2em 0 1em 0;
+	padding: 2em 0 1em 0;
 }
 
 article > header h1 {
-  line-height: 1.1;
+	line-height: 1.1;
 }
 
 article > header h1,
 article > header h2 {
-  margin: 0;
+	margin: 0;
 }
 
 article > header h1 + h2 {
-  font-size: 1.1rem;
-  margin-top: 0;
-  font-weight: normal;
+	font-size: 1.1rem;
+	margin-top: 0;
+	font-weight: normal;
 }
 
 article > header small span {
-  background-color: var(--accent);
-  color: var(--background);
-  padding: 2px 5px;
-  border-radius: 2px;
+	background-color: var(--accent);
+	color: var(--background);
+	padding: 2px 5px;
+	border-radius: 2px;
 }
 
 article > header small + h1,
 article.resource.bookmark aside + h1 {
-  margin: 0.67rem 0;
-  font-size: 3rem;
+	margin: 0.67rem 0;
+	font-size: 3rem;
 }
 
 article p {
-  text-align: left;
+	text-align: left;
 }
 
 article.note img:not(.btn-88x31) {
-  max-width: 100%;
-  height: auto;
+	max-width: 100%;
+	height: auto;
 }
 
 article.note > header h1 {
-  font-size: clamp(2rem, 6vw, 6rem);
+	font-size: clamp(2rem, 6vw, 6rem);
 }
 
 article.book > header h1 + h2 {
-  font-size: 1.4rem;
+	font-size: 1.4rem;
 }
 
 article.writing-index section > header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
 }
 
 article.resource.bookmark header > aside {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  column-gap: 1rem;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	column-gap: 1rem;
 }
 
 article.resource.bookmark header > aside ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  width: auto;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	width: auto;
 }
 
 article.resource.bookmark header > aside li {
-  display: inline-block;
+	display: inline-block;
 }
 
 article.resource.bookmark img.preview {
-  border: 2px solid var(--background-muted);
-  border-radius: 3px;
-  max-width: 100%;
-  height: auto;
+	border: 2px solid var(--background-muted);
+	border-radius: 3px;
+	max-width: 100%;
+	height: auto;
 }
 
 article.resource.bookmark div.meta ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  display: flex;
-  gap: 1rem;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	display: flex;
+	gap: 1rem;
 }
 
 article.resource.bookmark div.meta aside {
-  padding: 1em;
-  margin: 1em 0;
-  background: var(--background-muted);
+	padding: 1em;
+	margin: 1em 0;
+	background: var(--background-muted);
 }
 
 article.resource.bookmark div.meta p {
-  text-align: left;
-  margin: 0;
-  width: 100%;
-  font-size: 0.9em;
+	text-align: left;
+	margin: 0;
+	width: 100%;
+	font-size: 0.9em;
 }
 
 article.resource.bookmark .bookmark-link {
-  font-size: 1.4em;
-  line-break: anywhere;
+	font-size: 1.4em;
+	line-break: anywhere;
 }
 
 article.resource.bookmark .btn-list {
-  padding: 1em;
-  background: var(--background-muted);
-  margin: 1em 0;
+	padding: 1em;
+	background: var(--background-muted);
+	margin: 1em 0;
 }
 
 article.resource.bookmark .btn-list h4 {
-  margin-top: 0;
-  margin-bottom: 0.5em;
-  font-size: 0.9em;
+	margin-top: 0;
+	margin-bottom: 0.5em;
+	font-size: 0.9em;
 }
 
 article.resource.bookmark .btn-list ul {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5em;
-  width: 100%;
-  list-style: none;
-  padding: 0;
-  margin: 0;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5em;
+	width: 100%;
+	list-style: none;
+	padding: 0;
+	margin: 0;
 }
 
 article.resource.bookmark .btn-list li {
-  height: 31px;
+	height: 31px;
 }
 
-
 .tags-list ul {
-  display: grid;
-  width: 100%;
-  max-width: 100%;
-  grid-template-columns: 1fr 1fr 1fr;
+	display: grid;
+	width: 100%;
+	max-width: 100%;
+	grid-template-columns: 1fr 1fr 1fr;
 }
 
 .margin-note {
-  float: right;
-  clear: right;
-  margin-right: -50%;
-  width: 45%;
+	float: right;
+	clear: right;
+	margin-right: -50%;
+	width: 45%;
 }
 
 .margin-note img {
-  max-width: 100%;
-  min-width: auto;
+	max-width: 100%;
+	min-width: auto;
 }
 
 aside.margin-note {
-  width: 85%;
-  max-width: 864px;
-  padding-left: 2em;
-  margin-right: calc(-50% + 2em);
+	width: 85%;
+	max-width: 864px;
+	padding-left: 2em;
+	margin-right: calc(-50% + 2em);
 }
 
 .with-sub-title {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .with-sub-title + p {
-  margin-top: 0;
+	margin-top: 0;
 }
 
 /* Theme selector */
 .theme-picker {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  font-size: 0.875rem;
-  background-color: var(--background-muted);
-  box-shadow: 0 1px 0 0 rgb(0 0 0 / 10%);
-  height: 0;
-  overflow: hidden;
-  position: relative;
-  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 100%;
+	font-size: 0.875rem;
+	background-color: var(--background-muted);
+	box-shadow: 0 1px 0 0 rgb(0 0 0 / 10%);
+	height: 0;
+	overflow: hidden;
+	position: relative;
+	transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .theme-picker.is-open {
-  height: 11rem;
+	height: 11rem;
 }
 
 .theme-picker h1 {
-  font-size: 1.4em;
-  text-align: center;
-  margin-bottom: 0;
+	font-size: 1.4em;
+	text-align: center;
+	margin-bottom: 0;
 }
 
 .theme-picker nav {
-  position: relative;
-  z-index: 2;
-  width: 100%;
-  overflow-y: hidden;
-  scroll-behavior: smooth;
+	position: relative;
+	z-index: 2;
+	width: 100%;
+	overflow-y: hidden;
+	scroll-behavior: smooth;
 }
 
 .theme-picker ul {
-  display: flex;
-  flex-direction: row;
-  list-style: none;
-  margin: 0;
-  padding: 1em 40px 2em;
-  white-space: nowrap;
-  overflow-y: hidden;
-  overflow-x: auto;
-  text-align: center;
-  width: 100%;
+	display: flex;
+	flex-direction: row;
+	list-style: none;
+	margin: 0;
+	padding: 1em 40px 2em;
+	white-space: nowrap;
+	overflow-y: hidden;
+	overflow-x: auto;
+	text-align: center;
+	width: 100%;
 }
 
 .theme-picker li {
-  border-radius: 0.4em;
-  min-width: 140px;
-  transform: scale(1);
-  transition: transform 0.2s;
+	border-radius: 0.4em;
+	min-width: 140px;
+	transform: scale(1);
+	transition: transform 0.2s;
 }
 
 .theme-picker li:hover {
-  box-shadow: 0 0 8px var(--foreground);
-  transform: scale(1.05);
+	box-shadow: 0 0 8px var(--foreground);
+	transform: scale(1.05);
 }
 
 .theme-picker li.current {
-  box-shadow: 0 0 0 2px var(--accent);
+	box-shadow: 0 0 0 2px var(--accent);
 }
 
 .theme-picker li + li {
-  margin-left: 1rem;
+	margin-left: 1rem;
 }
 
 .theme-picker li button {
-  background-color: var(--background);
-  color: var(--foreground);
-  border: none;
-  border-radius: 0.4em;
-  padding: 1em;
-  font-size: 0.9em;
-  width: 100%;
-  cursor: pointer;
+	background-color: var(--background);
+	color: var(--foreground);
+	border: none;
+	border-radius: 0.4em;
+	padding: 1em;
+	font-size: 0.9em;
+	width: 100%;
+	cursor: pointer;
 }
 
 .theme-picker .swatches {
-  margin-top: 0.5em;
-  display: block;
+	margin-top: 0.5em;
+	display: block;
 }
 
 .theme-picker .swatches span {
-  display: inline-block;
-  width: 22px;
-  height: 22px;
-  border-radius: 100%;
-  background-color: black;
-  border: 2px solid white;
+	display: inline-block;
+	width: 22px;
+	height: 22px;
+	border-radius: 100%;
+	background-color: black;
+	border: 2px solid white;
 }
 
 .theme-picker .swatches span + span {
-  margin-left: -0.995em;
+	margin-left: -0.995em;
 }
 
 .theme-picker .swatches span.background {
-  background-color: var(--background);
+	background-color: var(--background);
 }
 
 .theme-picker .swatches span.background-muted {
-  background-color: var(--background-muted);
+	background-color: var(--background-muted);
 }
 
 .theme-picker .swatches span.foreground {
-  background-color: var(--foreground);
+	background-color: var(--foreground);
 }
 
 .theme-picker .swatches span.foreground-muted {
-  background-color: var(--foreground-muted);
+	background-color: var(--foreground-muted);
 }
 
 .theme-picker .swatches span.accent {
-  background-color: var(--accent);
+	background-color: var(--accent);
 }
 
 ul.alphabet {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  gap: 0.5em;
-  flex-wrap: wrap;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	gap: 0.5em;
+	flex-wrap: wrap;
 }
 
 .down-the-rabbit-hole {
-  position: relative;
+	position: relative;
 }
 
 .down-the-rabbit-hole img {
-  position: absolute;
-  top: -200px;
+	position: absolute;
+	top: -200px;
 }
 
-.page-meta{
-  position: relative;
-  background-color: var(--background-muted);
-  border-top: 3px solid var(--accent);
-  margin-top: 3rem;
+.page-meta {
+	position: relative;
+	background-color: var(--background-muted);
+	border-top: 3px solid var(--accent);
+	margin-top: 3rem;
 }
 
 .page-meta > div {
-  max-height: 0;
-  overflow: hidden;
-  display: none;
-  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  padding: 1rem 0;
+	max-height: 0;
+	overflow: hidden;
+	display: none;
+	transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+	padding: 1rem 0;
 }
 
 .page-meta > div:target {
-  display: block;
-  max-height: 9999px;
+	display: block;
+	max-height: 9999px;
 }
 
 .page-meta .pull-tab {
-  background-color: var(--background-muted);
-  position: absolute;
-  top: -2.5rem;
-  padding: 0 0.5rem;
-  height: 2.5rem;
-  border-top: 3px solid var(--accent);
-  display: flex;
-  align-items: center;
+	background-color: var(--background-muted);
+	position: absolute;
+	top: -2.5rem;
+	padding: 0 0.5rem;
+	height: 2.5rem;
+	border-top: 3px solid var(--accent);
+	display: flex;
+	align-items: center;
 }
 
 @media (max-width: 864px) {
-  .container {
-    margin: 0;
-    width: 100%;
-    padding: 0 1em;
-  }
+	.container {
+		margin: 0;
+		width: 100%;
+		padding: 0 1em;
+	}
 
-  body > header > div.container{
-    margin-top: 40px;
-  }
+	body > header > div.container {
+		margin-top: 40px;
+	}
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19,92 +19,91 @@
 @import "components/_terminal-tau.css";
 
 * {
-	box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .container {
-	max-width: 1440px;
-	width: 75%;
-	margin-left: 12.5%;
-	margin-right: 12.5%;
+  max-width: 1440px;
+  width: 75%;
+  margin-left: 12.5%;
+  margin-right: 12.5%;
 }
 
 body {
-	font-family: "Iosevka Etoile", monospace;
-	background-color: var(--background);
-	color: var(--foreground);
+  font-family: "Iosevka Etoile", monospace;
+  background-color: var(--background);
+  color: var(--foreground);
 
-	font-size: 1rem;
-	line-height: 1.54;
-	letter-spacing: -0.02em;
-	text-rendering: optimizeLegibility;
-	font-feature-settings: "liga", "tnum", "case", "calt", "zero", "ss01",
-		"locl";
-	font-variant-ligatures: contextual;
+  font-size: 1rem;
+  line-height: 1.54;
+  letter-spacing: -0.02em;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga", "tnum", "case", "calt", "zero", "ss01", "locl";
+  font-variant-ligatures: contextual;
 
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
-	transition: background-color 300ms, color 200ms;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  transition: background-color 300ms, color 200ms;
 }
 
 details summary {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 blockquote {
-	margin-inline-start: 0;
-	font-style: italic;
-	border-left: 3px solid var(--foreground-muted);
-	padding-left: 1em;
-	color: var(--foreground-muted);
+  margin-inline-start: 0;
+  font-style: italic;
+  border-left: 3px solid var(--foreground-muted);
+  padding-left: 1em;
+  color: var(--foreground-muted);
 }
 
 aside.citation {
-	border-left: 3px solid var(--foreground-muted);
-	padding-left: 1em;
+  border-left: 3px solid var(--foreground-muted);
+  padding-left: 1em;
 }
 
 aside.citation blockquote {
-	border-left: none;
-	padding-left: 0;
+  border-left: none;
+  padding-left: 0;
 }
 
 pre {
-	background: var(--background-muted);
-	color: var(--foreground);
-	border-radius: 0.5em;
-	overflow: scroll;
-	padding: 1em;
+  background: var(--background-muted);
+  color: var(--foreground);
+  border-radius: 0.5em;
+  overflow: scroll;
+  padding: 1em;
 }
 
 p > code {
-	background: var(--foreground-muted);
-	color: var(--background);
-	padding: 0 3px;
-	border-radius: 3px;
+  background: var(--foreground-muted);
+  color: var(--background);
+  padding: 0 3px;
+  border-radius: 3px;
 }
 
 hr {
-	border: 0;
-	border-bottom: 3px double var(--foreground-muted);
-	margin: 2rem 0;
-	min-width: 1em;
+  border: 0;
+  border-bottom: 3px double var(--foreground-muted);
+  margin: 2rem 0;
+  min-width: 1em;
 }
 
 figure.fullwidth img {
-	float: none;
+  float: none;
 }
 
 figure.fullwidth figcaption {
-	margin-right: 0;
-	max-width: 90%;
-	float: none;
+  margin-right: 0;
+  max-width: 90%;
+  float: none;
 }
 
 a:link,
 a:visited {
-	color: var(--accent);
+  color: var(--accent);
 }
 
 /* With thanks to the user Shaz @ Stack Overflow
@@ -119,385 +118,385 @@ a[href]:not(:where(
   /* subdomains to exclude */
   [href*="//www.photogabble.co.uk"]
 )):not(.no-ext):after {
-	content: "↗️";
-	margin-left: 0.25rem;
-	vertical-align: super;
-	font-size: 0.5rem;
+  content: "↗️";
+  margin-left: 0.25rem;
+  vertical-align: super;
+  font-size: 0.5rem;
 }
 
 a.no-underline {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 ::selection,
 .selected {
-	background-color: var(--accent);
-	color: var(--background);
+  background-color: var(--accent);
+  color: var(--background);
 }
 
 .selected {
-	padding: 0 0.2rem;
+  padding: 0 0.2rem;
 }
 
 main,
 header {
-	display: flex;
-	flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 main {
-	font-size: 1.2em;
-	flex-grow: 1;
-	margin-bottom: 2em;
+  font-size: 1.2em;
+  flex-grow: 1;
+  margin-bottom: 2em;
 }
 
 main > section {
-	text-wrap: balance;
-	text-wrap: pretty;
-	overflow: hidden;
+  text-wrap: balance;
+  text-wrap: pretty;
+  overflow: hidden;
 }
 
 article > header {
-	padding: 2em 0 1em 0;
+  padding: 2em 0 1em 0;
 }
 
 article > header h1 {
-	line-height: 1.1;
+  line-height: 1.1;
 }
 
 article > header h1,
 article > header h2 {
-	margin: 0;
+  margin: 0;
 }
 
 article > header h1 + h2 {
-	font-size: 1.1rem;
-	margin-top: 0;
-	font-weight: normal;
+  font-size: 1.1rem;
+  margin-top: 0;
+  font-weight: normal;
 }
 
 article > header small span {
-	background-color: var(--accent);
-	color: var(--background);
-	padding: 2px 5px;
-	border-radius: 2px;
+  background-color: var(--accent);
+  color: var(--background);
+  padding: 2px 5px;
+  border-radius: 2px;
 }
 
 article > header small + h1,
 article.resource.bookmark aside + h1 {
-	margin: 0.67rem 0;
-	font-size: 3rem;
+  margin: 0.67rem 0;
+  font-size: 3rem;
 }
 
 article p {
-	text-align: left;
+  text-align: left;
 }
 
 article.note img:not(.btn-88x31) {
-	max-width: 100%;
-	height: auto;
+  max-width: 100%;
+  height: auto;
 }
 
 article.note > header h1 {
-	font-size: clamp(2rem, 6vw, 6rem);
+  font-size: clamp(2rem, 6vw, 6rem);
 }
 
 article.book > header h1 + h2 {
-	font-size: 1.4rem;
+  font-size: 1.4rem;
 }
 
 article.writing-index section > header {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 article.resource.bookmark header > aside {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	column-gap: 1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  column-gap: 1rem;
 }
 
 article.resource.bookmark header > aside ul {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	width: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
 }
 
 article.resource.bookmark header > aside li {
-	display: inline-block;
+  display: inline-block;
 }
 
 article.resource.bookmark img.preview {
-	border: 2px solid var(--background-muted);
-	border-radius: 3px;
-	max-width: 100%;
-	height: auto;
+  border: 2px solid var(--background-muted);
+  border-radius: 3px;
+  max-width: 100%;
+  height: auto;
 }
 
 article.resource.bookmark div.meta ul {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	width: 100%;
-	display: flex;
-	gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  display: flex;
+  gap: 1rem;
 }
 
 article.resource.bookmark div.meta aside {
-	padding: 1em;
-	margin: 1em 0;
-	background: var(--background-muted);
+  padding: 1em;
+  margin: 1em 0;
+  background: var(--background-muted);
 }
 
 article.resource.bookmark div.meta p {
-	text-align: left;
-	margin: 0;
-	width: 100%;
-	font-size: 0.9em;
+  text-align: left;
+  margin: 0;
+  width: 100%;
+  font-size: 0.9em;
 }
 
 article.resource.bookmark .bookmark-link {
-	font-size: 1.4em;
-	line-break: anywhere;
+  font-size: 1.4em;
+  line-break: anywhere;
 }
 
 article.resource.bookmark .btn-list {
-	padding: 1em;
-	background: var(--background-muted);
-	margin: 1em 0;
+  padding: 1em;
+  background: var(--background-muted);
+  margin: 1em 0;
 }
 
 article.resource.bookmark .btn-list h4 {
-	margin-top: 0;
-	margin-bottom: 0.5em;
-	font-size: 0.9em;
+  margin-top: 0;
+  margin-bottom: 0.5em;
+  font-size: 0.9em;
 }
 
 article.resource.bookmark .btn-list ul {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 0.5em;
-	width: 100%;
-	list-style: none;
-	padding: 0;
-	margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 article.resource.bookmark .btn-list li {
-	height: 31px;
+  height: 31px;
 }
 
 .tags-list ul {
-	display: grid;
-	width: 100%;
-	max-width: 100%;
-	grid-template-columns: 1fr 1fr 1fr;
+  display: grid;
+  width: 100%;
+  max-width: 100%;
+  grid-template-columns: 1fr 1fr 1fr;
 }
 
 .margin-note {
-	float: right;
-	clear: right;
-	margin-right: -50%;
-	width: 45%;
+  float: right;
+  clear: right;
+  margin-right: -50%;
+  width: 45%;
 }
 
 .margin-note img {
-	max-width: 100%;
-	min-width: auto;
+  max-width: 100%;
+  min-width: auto;
 }
 
 aside.margin-note {
-	width: 85%;
-	max-width: 864px;
-	padding-left: 2em;
-	margin-right: calc(-50% + 2em);
+  width: 85%;
+  max-width: 864px;
+  padding-left: 2em;
+  margin-right: calc(-50% + 2em);
 }
 
 .with-sub-title {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .with-sub-title + p {
-	margin-top: 0;
+  margin-top: 0;
 }
 
 /* Theme selector */
 .theme-picker {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	width: 100%;
-	font-size: 0.875rem;
-	background-color: var(--background-muted);
-	box-shadow: 0 1px 0 0 rgb(0 0 0 / 10%);
-	height: 0;
-	overflow: hidden;
-	position: relative;
-	transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  font-size: 0.875rem;
+  background-color: var(--background-muted);
+  box-shadow: 0 1px 0 0 rgb(0 0 0 / 10%);
+  height: 0;
+  overflow: hidden;
+  position: relative;
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .theme-picker.is-open {
-	height: 11rem;
+  height: 11rem;
 }
 
 .theme-picker h1 {
-	font-size: 1.4em;
-	text-align: center;
-	margin-bottom: 0;
+  font-size: 1.4em;
+  text-align: center;
+  margin-bottom: 0;
 }
 
 .theme-picker nav {
-	position: relative;
-	z-index: 2;
-	width: 100%;
-	overflow-y: hidden;
-	scroll-behavior: smooth;
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
 }
 
 .theme-picker ul {
-	display: flex;
-	flex-direction: row;
-	list-style: none;
-	margin: 0;
-	padding: 1em 40px 2em;
-	white-space: nowrap;
-	overflow-y: hidden;
-	overflow-x: auto;
-	text-align: center;
-	width: 100%;
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  margin: 0;
+  padding: 1em 40px 2em;
+  white-space: nowrap;
+  overflow-y: hidden;
+  overflow-x: auto;
+  text-align: center;
+  width: 100%;
 }
 
 .theme-picker li {
-	border-radius: 0.4em;
-	min-width: 140px;
-	transform: scale(1);
-	transition: transform 0.2s;
+  border-radius: 0.4em;
+  min-width: 140px;
+  transform: scale(1);
+  transition: transform 0.2s;
 }
 
 .theme-picker li:hover {
-	box-shadow: 0 0 8px var(--foreground);
-	transform: scale(1.05);
+  box-shadow: 0 0 8px var(--foreground);
+  transform: scale(1.05);
 }
 
 .theme-picker li.current {
-	box-shadow: 0 0 0 2px var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
 }
 
 .theme-picker li + li {
-	margin-left: 1rem;
+  margin-left: 1rem;
 }
 
 .theme-picker li button {
-	background-color: var(--background);
-	color: var(--foreground);
-	border: none;
-	border-radius: 0.4em;
-	padding: 1em;
-	font-size: 0.9em;
-	width: 100%;
-	cursor: pointer;
+  background-color: var(--background);
+  color: var(--foreground);
+  border: none;
+  border-radius: 0.4em;
+  padding: 1em;
+  font-size: 0.9em;
+  width: 100%;
+  cursor: pointer;
 }
 
 .theme-picker .swatches {
-	margin-top: 0.5em;
-	display: block;
+  margin-top: 0.5em;
+  display: block;
 }
 
 .theme-picker .swatches span {
-	display: inline-block;
-	width: 22px;
-	height: 22px;
-	border-radius: 100%;
-	background-color: black;
-	border: 2px solid white;
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  border-radius: 100%;
+  background-color: black;
+  border: 2px solid white;
 }
 
 .theme-picker .swatches span + span {
-	margin-left: -0.995em;
+  margin-left: -0.995em;
 }
 
 .theme-picker .swatches span.background {
-	background-color: var(--background);
+  background-color: var(--background);
 }
 
 .theme-picker .swatches span.background-muted {
-	background-color: var(--background-muted);
+  background-color: var(--background-muted);
 }
 
 .theme-picker .swatches span.foreground {
-	background-color: var(--foreground);
+  background-color: var(--foreground);
 }
 
 .theme-picker .swatches span.foreground-muted {
-	background-color: var(--foreground-muted);
+  background-color: var(--foreground-muted);
 }
 
 .theme-picker .swatches span.accent {
-	background-color: var(--accent);
+  background-color: var(--accent);
 }
 
 ul.alphabet {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	display: flex;
-	gap: 0.5em;
-	flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.5em;
+  flex-wrap: wrap;
 }
 
 .down-the-rabbit-hole {
-	position: relative;
+  position: relative;
 }
 
 .down-the-rabbit-hole img {
-	position: absolute;
-	top: -200px;
+  position: absolute;
+  top: -200px;
 }
 
 .page-meta {
-	position: relative;
-	background-color: var(--background-muted);
-	border-top: 3px solid var(--accent);
-	margin-top: 3rem;
+  position: relative;
+  background-color: var(--background-muted);
+  border-top: 3px solid var(--accent);
+  margin-top: 3rem;
 }
 
 .page-meta > div {
-	max-height: 0;
-	overflow: hidden;
-	display: none;
-	transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-	padding: 1rem 0;
+  max-height: 0;
+  overflow: hidden;
+  display: none;
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  padding: 1rem 0;
 }
 
 .page-meta > div:target {
-	display: block;
-	max-height: 9999px;
+  display: block;
+  max-height: 9999px;
 }
 
 .page-meta .pull-tab {
-	background-color: var(--background-muted);
-	position: absolute;
-	top: -2.5rem;
-	padding: 0 0.5rem;
-	height: 2.5rem;
-	border-top: 3px solid var(--accent);
-	display: flex;
-	align-items: center;
+  background-color: var(--background-muted);
+  position: absolute;
+  top: -2.5rem;
+  padding: 0 0.5rem;
+  height: 2.5rem;
+  border-top: 3px solid var(--accent);
+  display: flex;
+  align-items: center;
 }
 
 @media (max-width: 864px) {
-	.container {
-		margin: 0;
-		width: 100%;
-		padding: 0 1em;
-	}
+  .container {
+    margin: 0;
+    width: 100%;
+    padding: 0 1em;
+  }
 
-	body > header > div.container {
-		margin-top: 40px;
-	}
+  body > header > div.container {
+    margin-top: 40px;
+  }
 }


### PR DESCRIPTION
Hey! My layout for the home page is slightly different than yours, so definitely test on your side, but I noticed that particularly long unbroken strings can cause the homepage to gain a horizontal scroll leading to a difficult reading experience. This is a problem I have because Pocket occasionally drops unbroken URLs into my Amplify block, but may not happen on your site, but could one day. This fixed it on my site, I think it should fix it on yours as well if it happens there.

I also added an `.editorconfig` file. I don't think you use it, but by having it in your repo, future contributors who leverage EditorConfig can make changes without accidentally changing a ton of spacing in the files they touch. Even so, this comes with a bunch of spacing changes, sorry! 

The main change is at the top of `.content-grid` and `main > section`.   

The double rule of 

```
  text-wrap: balance;
  text-wrap: pretty;
```

is there because `pretty` looks better, but is not as broadly adopted across browsers as `balance` is. 