### PR TITLE
Add series links for notes that belong to one

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -82,7 +82,7 @@ const topics = (collection) => {
         carry.set(`list/${(post.data?.list_slug ?? post.fileSlug)}`, post);
         break;
       case 'series':
-        carry.set(`series/${post.fileSlug}`, post);
+        carry.set(post.data?.sidebar_topic ?? `series/${post.fileSlug}`, post);
         break;
       case 'index':
         (post.data?.topic || post.data?.sidebar_topic || post.data?.sidebar_resource) &&

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -301,6 +301,18 @@ export const includesTag = memoize(
 );
 
 /**
+ * Check if a given tag list contains a special tag.
+ *
+ * @param tags {Array<string>}
+ * @param slug {string}
+ * @returns {boolean}
+ */
+export const includesSpecialTag = memoize(
+  (tags, slug) => tags.find(tag => tag.toLowerCase().startsWith(slug.toLowerCase())) !== undefined,
+  {cacheKey: arguments_ => `${arguments_[0].join(',')}_${arguments_[1]}`}
+)
+
+/**
  * Excludes special tags matching key. If key is empty then it excludes all special tags.
  *
  * @param {Array<String>} tags
@@ -918,6 +930,9 @@ export const registerFilters = (eleventyConfig) => {
   eleventyConfig.addFilter('trackBacklink', trackBacklink);
   eleventyConfig.addFilter('includesTag', includesTag);
   eleventyConfig.addFilter('excerpt', excerpt);
+
+  // This is used by page.njk for displaying the series sidebar component
+  eleventyConfig.addFilter('includesSpecialTag', includesSpecialTag);
 
   // Used for debugging
   eleventyConfig.addFilter('debug', debug);

--- a/src/_includes/components/side-bars/series.njk
+++ b/src/_includes/components/side-bars/series.njk
@@ -1,0 +1,16 @@
+{% set seriesId = tags | specialTagValue('series') %}
+{% set seriesMeta = collections.topics | whereKeyEquals('topic', 'series/' + seriesId) | first %}
+
+<section class="post-list">
+    <header class="post-list__inline-header">
+        <h3>{{ seriesMeta.name }}</h3> {{ seriesMeta.items.length }} {% if seriesMeta.items.length > 1 %}items{% else %}item{% endif %}
+    </header>
+    <ol class="post-list__chronological">
+        {%- for post in seriesMeta.items -%}
+            {% include "components/post-list-line.njk" %}
+        {%- endfor -%}
+    </ol>
+    <footer>
+        <nav><a href="{{ seriesMeta.permalink }}">{{ seriesMeta.name }} Overview</a> | <a href="/series/">All Series</a></nav>
+    </footer>
+</section>

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -14,6 +14,9 @@
 {% endblock %}
 
 {% block sidebar %}
+    {% if tags | includesSpecialTag('series') %}
+        {% include 'components/side-bars/series.njk' %}
+    {% endif %}
     {% if sidebar_component %}
         {% set sidebar_component_include = 'components/side-bars/' + sidebar_component + '.njk' %}
         {% include sidebar_component_include %}


### PR DESCRIPTION
This PR solves #355 by adding a contents listing of the series a note belongs to.