### PR TITLE
Add content type list on /writing/ page

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -109,17 +109,23 @@ export const randomItems = (arr, count) => {
 }
 
 /**
- * Returns list filtered to only include items where key matches value.
+ * Returns list filtered to only include items where key matches value. This supports
+ * wildcards for example value='type/*'.
  *
  * @param {Array<any>} collection
  * @param {String} key
- * @param {String|Array<String>}value
+ * @param {String|boolean|Array<String>}value
  * @return {Array<any>}
  */
 export const whereKeyEquals = (collection, key, value) =>
   Array.isArray(value)
     ? collection.filter(item => value.includes(item[key]) || (item.data && value.includes(item.data[key])))
-    : collection.filter(item => item[key] === value || (item.data && item.data[key] === value));
+    : collection.filter(item => {
+      if (typeof value === 'string' && value.includes('/*')) {
+        return item[key].startsWith(`${value.split('/')[0]}/`);
+      }
+      return item[key] === value || (item.data && item.data[key] === value);
+    });
 
 export const whereKeyFalse = (collection, key) => collection.filter(item => item[key] === false || typeof item[key] === 'undefined');
 
@@ -178,25 +184,12 @@ export const specialTagMeta = (list) => {
  * Takes a list of tags and returns them mapped as topic or list items.
  *
  * @param list {Array<string>}
+ * @param topics {Array<any>}
  * @returns {Array<{title: string, description: string, slug:string, url: string}>}
  */
-export const formatTagList = (list) => {
+export const formatTagList = (list, topics = []) => {
   return (list)
-    ? list.map((tag) => {
-
-      if (isSpecialTag(tag)) {
-        return specialTagMeta(tag);
-      }
-
-      const slug = slugify(tag);
-
-      return {
-        title: tag,
-        description: '',
-        slug,
-        permalink: `/topic/${slug}`,
-      }
-    })
+    ? topics.filter(({topic}) => list.includes(topic))
     : [];
 };
 

--- a/src/_includes/components/side-bars/writing.njk
+++ b/src/_includes/components/side-bars/writing.njk
@@ -4,13 +4,12 @@
 
 <hr/>
 
-{% set contentTypes = collections | specialTagsInCollection('type', ['type/resource', 'type/project', 'type/topic', 'stage/stub']) %}
+{% set contentTypes = collections.topics | whereKeyEquals('topic', 'type/*') %}
 <section>
     <nav>
         {% for contentType in contentTypes %}
-            {% set isContentType = tags | includes(contentType.name) %}
-            {% set currentContentType = metadata.contentTypes[contentType.name] %}
-            <a href="{{ contentType.permalink }}">{{ contentType.title or contentType.name }} ({{ contentType.usages }}){% if isContentType %}*{% endif %}</a>
+            {% set isContentType = tags | includes(contentType.topic) %}
+            <a href="{{ contentType.permalink }}">{{ contentType.title or contentType.name }}{% if isContentType %}*{% endif %}</a>
         {% endfor %}
     </nav>
 </section>


### PR DESCRIPTION
This PR solves #331 by using the new topics collection filtered by `type/*` in order to display links to content type pages.