### PR TITLE
Hide prev/next on taxonomy pages

### DIFF
--- a/src/_includes/components/page-article.njk
+++ b/src/_includes/components/page-article.njk
@@ -47,7 +47,8 @@
                 </nav>
             </section>
         {% endif %}
-        {% if previousPost or nextPost %}
+
+        {% if show_prev_next and (previousPost or nextPost) %}
             <section>
                 <h3>Next in this series</h3>
                 <nav class="related-notes related-notes__next-previous">

--- a/src/content/content.11tydata.js
+++ b/src/content/content.11tydata.js
@@ -3,6 +3,7 @@ import {dateToFormat, notTagged, specialTagValue} from "../../lib/filters.js";
 
 export default {
   show_related: true,
+  show_prev_next: true,
   featured: false,
   draft: false,
   excludeFromFeed: false,
@@ -11,6 +12,7 @@ export default {
   // TODO: (RC2024) remove growthStage and contentType
   growthStage: 'seedling', // seedling, budding, evergreen
   contentType: 'thought', // thought, noteworthy, essay, tutorial, project
+
   eleventyComputed: {
     //changes: data => getChanges(data),
     // niceDate: stops dateToFormat being hit hundreds of thousands of times

--- a/src/content/taxonomy/series/series.11tydata.js
+++ b/src/content/taxonomy/series/series.11tydata.js
@@ -8,6 +8,11 @@
  *
  */
 export default {
+  // Do not show related notes
+  show_related: false,
+  // Do not show prev/next links
+  show_prev_next: false,
+
   // Do not include in RSS Feed
   excludeFromFeed: true,
 

--- a/src/content/taxonomy/stage/stage.11tydata.js
+++ b/src/content/taxonomy/stage/stage.11tydata.js
@@ -3,6 +3,11 @@
  *
  */
 export default {
+  // Do not show related notes
+  show_related: false,
+  // Do not show prev/next links
+  show_prev_next: false,
+
   // Do not include in RSS Feed
   excludeFromFeed: true,
 

--- a/src/content/taxonomy/topics/topics.11tydata.js
+++ b/src/content/taxonomy/topics/topics.11tydata.js
@@ -5,6 +5,10 @@
  * an extensive personal history that I would like to share.
  */
 export default {
+  // Do not show related notes
+  show_related: false,
+  // Do not show prev/next links
+  show_prev_next: false,
   // Do not include in RSS Feed
   excludeFromFeed: true,
   // Tagged as special topic type, these aren't regular pages


### PR DESCRIPTION
This PR solves #333 by hiding prev/next and related notes footer sections on taxnonomy pages.