### PR TITLE
Add statistics blurb to topic index pages

### DIFF
--- a/src/_includes/components/page-article.njk
+++ b/src/_includes/components/page-article.njk
@@ -15,7 +15,6 @@
         {% set footnotes = content | extractFootnotes %}
         {{ content | withoutFootnotes | safe }}
     </section>
-
     <footer>
         {% if footnotes.length %}
             {{ footnotes | safe }}
@@ -75,6 +74,12 @@
                 </nav>
             </section>
         {% endif %}
+
+        {% if statistics_collection %}
+            {% set stats = statistics_collection.items | collectionStats %}
+            {% include "components/partials/article-footer-statistics.njk" %}
+        {% endif %}
+
         {#        <section>#}
         {#            <h3>Linking Here</h3>#}
         {#        </section>#}

--- a/src/_includes/components/partials/article-footer-statistics.njk
+++ b/src/_includes/components/partials/article-footer-statistics.njk
@@ -1,0 +1,10 @@
+{% if stats %}
+<section>
+    <h3>Statistics</h3>
+    <blockquote>
+        <p>
+            Since first published in <strong>{{ stats.firstItem.date | dateToFormat('yyyy') }}</strong> there have been <strong>{{ stats.totalItems }}</strong> notes added to this topic, containing an average of <strong>~{{ stats.avgWords }}</strong> words each for an overall total of <strong>{{ stats.totalWords }}</strong> words.
+        </p>
+    </blockquote>
+</section>
+{% endif %}

--- a/src/content/taxonomy/topics/topics.11tydata.js
+++ b/src/content/taxonomy/topics/topics.11tydata.js
@@ -20,6 +20,9 @@ export default {
   sidebar_component: 'topic',
 
   eleventyComputed: {
+    statistics_collection(data) {
+      return data.collections.topics.find(({topic}) => topic === (data.topic ?? data.title));
+    },
     permalink(data) {
       return `topic/${data.page.fileSlug}/`;
     },

--- a/src/topic/topic.njk
+++ b/src/topic/topic.njk
@@ -28,13 +28,9 @@
         <header>
             <h1>{{ topic.name }}</h1>
         </header>
-        <section>
-            <p>Hello world</p>
-        </section>
+        <footer>
+            {% set stats = topic.items | collectionStats %}
+            {% include "components/partials/article-footer-statistics.njk" %}
+        </footer>
     </article>
-    <div>
-        {% for topic in nakedTopics %}
-            <p>{{ topic }}</p>
-        {% endfor %}
-    </div>
 {% endblock %}


### PR DESCRIPTION
This solves #332 by adding some statistics to each topic page so that the right hand side of the screen doesn't remain empty.